### PR TITLE
fix: Food consistently places onto plate

### DIFF
--- a/VirtualChefs/Assets/Items/Scripts/Combine.cs
+++ b/VirtualChefs/Assets/Items/Scripts/Combine.cs
@@ -15,6 +15,7 @@ public struct Food
     public float height;
     public int priority;
 
+
     public Food(GameObject food, float[] foodHeights)
     {
         item = food;
@@ -53,6 +54,7 @@ public class Combine : MonoBehaviour
     private HandGrabInteractor handGrab; // Reference to the HandGrabInteractor component
 
     public List<Food> plate = new List<Food>();
+    public Collider foodCatcherCollider;
     public float[] foodHeights;
     public bool[] foods;
     public int size;
@@ -144,14 +146,9 @@ public class Combine : MonoBehaviour
         food.item.transform.localPosition = new Vector3(0, foodPosition + (food.height / 4), 0); // Place food exactly where it needs to be
     }
 
-
-    // Called when an item collides with plate
-    private void OnTriggerEnter(Collider other)
+    // Called after an item collides with the plate
+    public void AddFoodToPlate(Collider other)
     {
-        if (other.tag != "Untagged")
-        {
-            print("Collision with " + other.tag);
-        }
 
         Food food = new Food(other.gameObject, foodHeights);
         if (food.priority < 0 || inPlateAlready(food.tag))
@@ -208,7 +205,8 @@ public class Combine : MonoBehaviour
         }
 
         // Check if the object is still within the collision area of the plate
-        if (other.gameObject.GetComponent<Collider>().bounds.Intersects(GetComponent<Collider>().bounds))
+        //if (other.gameObject.GetComponent<Collider>().bounds.Intersects(GetComponent<Collider>().bounds))
+        if (other.gameObject.GetComponent<Collider>().bounds.Intersects(foodCatcherCollider.bounds))
         {
 
             // Food already physically placed

--- a/VirtualChefs/Assets/Resources/Prefabs/Combine/Plate.prefab
+++ b/VirtualChefs/Assets/Resources/Prefabs/Combine/Plate.prefab
@@ -71,6 +71,7 @@ Transform:
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 6643970105773690568}
+  - {fileID: 6574345734281266717}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &711322472107082782
@@ -238,6 +239,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 95e457106a5ee9447a8d3df71fe71127, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  foodCatcherCollider: {fileID: 2463727017398977472}
   foodHeights: []
   foods: 
   size: 0
@@ -272,8 +274,75 @@ BoxCollider:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Size: {x: 0.42469153, y: 0.04, z: 0.42469153}
+  m_Size: {x: 0.42469153, y: 0.06, z: 0.42469153}
   m_Center: {x: 0, y: 0.02, z: 0}
+--- !u!1 &2631371836129706608
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6574345734281266717}
+  - component: {fileID: 2463727017398977472}
+  - component: {fileID: 7430050913183468027}
+  m_Layer: 0
+  m_Name: FoodCatcher
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6574345734281266717
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2631371836129706608}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.229, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 7662248368466116235}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &2463727017398977472
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2631371836129706608}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 0.4, y: 0.57, z: 0.4}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &7430050913183468027
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2631371836129706608}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e6d8dd2ee723e4d40851f3cbd0f68972, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  combineScript: {fileID: 8911249764134592037}
 --- !u!1 &4617701470562256165
 GameObject:
   m_ObjectHideFlags: 0

--- a/VirtualChefs/Assets/Scripts/CuttingScripts/FoodCatcher.cs
+++ b/VirtualChefs/Assets/Scripts/CuttingScripts/FoodCatcher.cs
@@ -1,0 +1,13 @@
+using UnityEngine;
+
+public class FoodCatcher : MonoBehaviour
+{
+    // Reference to the Combine script on the plate GameObject
+    public Combine combineScript;
+
+    private void OnTriggerEnter(Collider other)
+    {
+        // Calls a method in the Combine script to add the food object to the plate
+        combineScript.AddFoodToPlate(other);
+    }
+}

--- a/VirtualChefs/Assets/Scripts/CuttingScripts/FoodCatcher.cs.meta
+++ b/VirtualChefs/Assets/Scripts/CuttingScripts/FoodCatcher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e6d8dd2ee723e4d40851f3cbd0f68972
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
A previous alteration to the plate's collider introduced new issues in food placement.

When attempting to place food, its gravity after being released from grab would drop the food outside of the plate's collision box.

Added a child collision box to the plate, created a new Food Catcher script, altered combine script and connected everything together.