### PR TITLE
fix: change behavior of desk objects visualizers

### DIFF
--- a/VirtualChefs/Assets/Assets-Scene/Prefabs/Placement/PlacementVisualisers/StovetopVisualizer.prefab
+++ b/VirtualChefs/Assets/Assets-Scene/Prefabs/Placement/PlacementVisualisers/StovetopVisualizer.prefab
@@ -88,7 +88,7 @@ MonoBehaviour:
     m_Bits: 2048
   m_layerMaskFloor:
     serializedVersion: 2
-    m_Bits: 4096
+    m_Bits: 8192
   m_placementType: 2
   m_useMaxWallHeight: 0
   m_maxWallHeight: 1
@@ -196,7 +196,7 @@ MonoBehaviour:
     m_Bits: 2048
   m_layerMaskFloor:
     serializedVersion: 2
-    m_Bits: 4096
+    m_Bits: 8192
   m_placementType: 2
   m_useMaxWallHeight: 0
   m_maxWallHeight: 1
@@ -319,7 +319,7 @@ MonoBehaviour:
     m_Bits: 2048
   m_layerMaskFloor:
     serializedVersion: 2
-    m_Bits: 4096
+    m_Bits: 8192
   m_placementType: 2
   m_useMaxWallHeight: 0
   m_maxWallHeight: 1
@@ -390,13 +390,13 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_userInteractableObject: 1
-  m_radius: 0.5145
+  m_radius: 0.28875
   m_placeAgainstWall: 0
   m_onTheWall: 0
   m_flipFaceDirection: 0
-  m_forceToGroundLevel: 1
-  m_wallObjectPlacementHeight: 0
-  m_wallObjectWidth: 0
+  m_forceToGroundLevel: 0
+  m_wallObjectPlacementHeight: 1.8
+  m_wallObjectWidth: 0.6787725
   m_wallObjectVerticalSize: 0
   m_objectType: 31
   m_grabbable: {fileID: 8713484567708071133}
@@ -407,8 +407,8 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 14336
   m_placementEaseTime: 3
-  m_distFromEdgeLeft: 0.6
-  m_distFromEdgeRight: 0.6
+  m_distFromEdgeLeft: 0
+  m_distFromEdgeRight: 0
   m_boxCollider: {fileID: 1518988667788268115}
 --- !u!65 &1518988667788268115
 BoxCollider:
@@ -430,7 +430,7 @@ BoxCollider:
   m_Enabled: 1
   serializedVersion: 3
   m_Size: {x: 0.5069443, y: 0.032364704, z: 0.5069165}
-  m_Center: {x: 0.002520278, y: -0.009378869, z: -0.050776184}
+  m_Center: {x: 0, y: 0.02, z: 0}
 --- !u!54 &9152792109826418118
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/VirtualChefs/Assets/Assets-Scene/Prefabs/Placement/PlacementVisualisers/TicketWheelVisualizer.prefab
+++ b/VirtualChefs/Assets/Assets-Scene/Prefabs/Placement/PlacementVisualisers/TicketWheelVisualizer.prefab
@@ -88,7 +88,7 @@ MonoBehaviour:
     m_Bits: 2048
   m_layerMaskFloor:
     serializedVersion: 2
-    m_Bits: 4096
+    m_Bits: 8192
   m_placementType: 2
   m_useMaxWallHeight: 0
   m_maxWallHeight: 1
@@ -196,7 +196,7 @@ MonoBehaviour:
     m_Bits: 2048
   m_layerMaskFloor:
     serializedVersion: 2
-    m_Bits: 4096
+    m_Bits: 8192
   m_placementType: 2
   m_useMaxWallHeight: 0
   m_maxWallHeight: 1
@@ -319,7 +319,7 @@ MonoBehaviour:
     m_Bits: 2048
   m_layerMaskFloor:
     serializedVersion: 2
-    m_Bits: 4096
+    m_Bits: 8192
   m_placementType: 2
   m_useMaxWallHeight: 0
   m_maxWallHeight: 1
@@ -368,8 +368,8 @@ Transform:
   m_GameObject: {fileID: 8045472780145166155}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.35782, z: -0.20657}
-  m_LocalScale: {x: 0.8579907, y: 0.8579907, z: 0.8579907}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 1
   m_Children:
   - {fileID: 3092953552703882141}
@@ -390,13 +390,13 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_userInteractableObject: 1
-  m_radius: 0.5145
+  m_radius: 0.28875
   m_placeAgainstWall: 0
   m_onTheWall: 0
   m_flipFaceDirection: 0
-  m_forceToGroundLevel: 1
-  m_wallObjectPlacementHeight: 0
-  m_wallObjectWidth: 0
+  m_forceToGroundLevel: 0
+  m_wallObjectPlacementHeight: 1.8
+  m_wallObjectWidth: 0.6787725
   m_wallObjectVerticalSize: 0
   m_objectType: 25
   m_grabbable: {fileID: 8713484567708071133}
@@ -405,7 +405,7 @@ MonoBehaviour:
     m_Bits: 24576
   m_physicsEnvironmentLayers:
     serializedVersion: 2
-    m_Bits: 8192
+    m_Bits: 14336
   m_placementEaseTime: 3
   m_distFromEdgeLeft: 0
   m_distFromEdgeRight: 0
@@ -430,7 +430,7 @@ BoxCollider:
   m_Enabled: 1
   serializedVersion: 3
   m_Size: {x: 0.5013638, y: 0.40965942, z: 0.42872897}
-  m_Center: {x: -0.010409686, y: 0.20210859, z: 0.01772066}
+  m_Center: {x: 0, y: 0.21, z: 0}
 --- !u!54 &9152792109826418118
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/VirtualChefs/Assets/Assets-Scene/Scripts/SceneManagement/SceneUnderstandingLocationPlacer.cs
+++ b/VirtualChefs/Assets/Assets-Scene/Scripts/SceneManagement/SceneUnderstandingLocationPlacer.cs
@@ -312,6 +312,7 @@ namespace CrypticCabinet.SceneManagement
 
             foundPosition = Vector3.zero;
             foundRotation = Quaternion.identity;
+
             return false;
         }
 
@@ -340,6 +341,7 @@ namespace CrypticCabinet.SceneManagement
 
             foundPosition = Vector3.zero;
             foundRotation = Quaternion.identity;
+            
             return false;
         }
 
@@ -442,7 +444,7 @@ namespace CrypticCabinet.SceneManagement
 
         public void RequestTotallyRandomDeskLocation(out Vector3 position)
         {
-            var foundDesks = m_horizontalSurfaces.Where(finder => finder is DeskSpaceFinder).ToList();
+            var foundDesks = m_horizontalSurfaces.Where(finder => finder is DeskSpaceFinder or FloorSpaceFinder).ToList();
 
             if (foundDesks.Count > 0)
             {

--- a/VirtualChefs/Assets/Assets-Scene/Scripts/Utils/ObjectPlacementManager.cs
+++ b/VirtualChefs/Assets/Assets-Scene/Scripts/Utils/ObjectPlacementManager.cs
@@ -166,21 +166,6 @@ namespace CrypticCabinet.Utils
             {
 
                 m_sceneUnderstandingLocationPlacer.RequestTotallyRandomDeskLocation(out var position);
-
-                var objectOnTables = new List<string> { "KNIFE", "CHOPPING_BOARD" };
-
-                // The objects inside this list we want them to always spawn on the virtual table even if a valid location on the real table was found
-                if (objectOnTables.Contains(deskObject.DisplayPrefab.GetObjectType.ToString()))
-                {
-                    position = Vector3.zero;
-                }
-                
-                // If a desk location was not found then spawn the object on a virtual table
-                if (position == Vector3.zero)
-                {
-                    SpawnDeskObjectsOnVirtualTable(deskObject, 0.5f, out position);
-                }
-
                 PlaceObjectLookAtUser(deskObject, userPos, position);
             }
 
@@ -195,48 +180,6 @@ namespace CrypticCabinet.Utils
                 m_sceneUnderstandingLocationPlacer.RequestTotallyRandomFloorLocation(out var position);
                 PlaceObjectLookAtUser(sceneObject, userPos, position);
             }
-        }
-
-        private void SpawnDeskObjectsOnVirtualTable(SceneObject sceneObject, float radiusMultiplier, out Vector3 position)
-        {
-            if (m_virtualTablePrefab == null)
-            {
-                Debug.LogError("Virtual Table prefab is not assigned in the Inspector!");
-                position = Vector3.zero;
-
-            }
-
-            // Find the Disabled Prefab under the Virtual Table prefab
-            // Get the Object Type of the sceneObject
-            LoadableSceneObjects objectType = sceneObject.DisplayPrefab.GetComponent<ObjectPlacementVisualiser>().GetObjectType;
-
-            // Find the child object under the Virtual Table with the same Object Type
-            Transform prefabTransform = null;
-
-            foreach (Transform childTransform in m_virtualTablePrefab.transform)
-            {
-                SimpleSceneObjectPlacer simpleSceneObjectPlacer = childTransform.GetComponent<SimpleSceneObjectPlacer>();
-                if (simpleSceneObjectPlacer != null && simpleSceneObjectPlacer.GetObjectType == objectType)
-                {
-                    prefabTransform = childTransform;
-                    break;
-                }
-            }
-
-            if (prefabTransform == null)
-            {
-                Debug.LogError($"Prefab not found under the Virtual Table for Object Type: {objectType}");
-                position = Vector3.zero;
-
-            }
-
-            /*// Enable the prefab
-            prefabTransform.gameObject.SetActive(true);*/
-
-            // Set the position of the sceneObject to the position of the prefab
-            position = prefabTransform.position;
-
-
         }
 
         private static void PlaceObject(SceneObject sceneObject, Vector3 targetPosition, Quaternion targetRotation)
@@ -280,7 +223,7 @@ namespace CrypticCabinet.Utils
             var floorObjectFailed = m_floorObject.Count(o => !o.SuccessfullyPlaced);
             var anyHorizontalObjectFailed = m_anyHorizontalObject.Count(o => !o.SuccessfullyPlaced);
             var totalFailed = againstWallObjectFailed + onWallObjectFailed + deskObjectFailed + floorObjectFailed +
-                              anyHorizontalObjectFailed;
+            anyHorizontalObjectFailed;
 
             return totalFailed;
         }
@@ -502,8 +445,6 @@ namespace CrypticCabinet.Utils
 
             for (var i = 0; i < m_deskObject.Count; i++)
             {
-
-                UISystem.Instance.ShowMessage("Inside the loop...");
                 var sceneObject = m_deskObject[i];
                 var successfullyPlaced = RequestRandomDeskLocation(ref sceneObject, 1.05f);
 
@@ -511,42 +452,28 @@ namespace CrypticCabinet.Utils
                 {
                     successfullyPlaced = RequestRandomDeskLocation(ref sceneObject, 0.5f);
                 }
- 
-                // Set the SuccessfullyPlaced property of the sceneObject to the value of successfullyPlaced
-                // This indicates whether the object was successfully placed or not
+
+                if (!successfullyPlaced)
+                {
+                    // failed to find any desk location looking for any horizontal location
+                    successfullyPlaced = RequestRandomLocation(ref sceneObject, 1.05f);
+                }
+
+                successfullyPlaced = true;
+                
                 sceneObject.SuccessfullyPlaced = successfullyPlaced;
-
-                // Set the WallPosition of the sceneObject to the same value as its MainPosition
-                // This is used when the object is placed against a wall
                 sceneObject.WallPosition = sceneObject.MainPosition;
-
-                // Calculate the rotation of the sceneObject based on its MainPosition and the FlipFaceDir property of its DisplayPrefab
-                // This ensures that the object is facing towards the user
                 sceneObject.MainRotation = GetRotationTowardsUser(sceneObject.MainPosition, sceneObject.DisplayPrefab.GetFlipFaceDir);
-
-                // Update the sceneObject in the m_deskObject list at index i with the modified sceneObject
                 m_deskObject[i] = sceneObject;
-
-                // Check if the DisplayPrefab of the sceneObject is null
                 if (sceneObject.DisplayPrefab == null)
                 {
-                    // If the DisplayPrefab is null, log an error message and skip the placement of this object
                     Debug.LogError("Scene Object without object visualizer! Skip placement");
-
-                    // Continue to the next iteration of the loop
                     continue;
                 }
 
-                // Instantiate a visualizer object for the sceneObject using the InstantiateVisualizer method
-                // This creates a visual representation of the object in the scene
                 var objectPlacementVisualiser = InstantiateVisualizer(ref sceneObject);
-
-                // Set up the instantiated visualizer object with the necessary information
-                // This includes passing the ObjectPlacementManager instance (this) and the MainPosition of the sceneObject
                 objectPlacementVisualiser.Setup(this, sceneObject.MainPosition);
 
-                // Update the sceneObject in the m_deskObject list at index i with the modified sceneObject again
-                // This is redundant and can be removed
                 m_deskObject[i] = sceneObject;
             }
         }


### PR DESCRIPTION
- User can now move visualizers across desks.
- Visualizers now correctly change color instead of always turning red when moved even when space on desk was valid.