### PR TITLE
fix: Tomato child object had missing material reference

### DIFF
--- a/VirtualChefs/Assets/Resources/Prefabs/Cut/TomatoBlock.prefab
+++ b/VirtualChefs/Assets/Resources/Prefabs/Cut/TomatoBlock.prefab
@@ -416,7 +416,7 @@ MeshRenderer:
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
-  - {fileID: 2100000, guid: 92885db60779e5f4fbc5d34db3037571, type: 2}
+  - {fileID: -8876429951165359728, guid: 1490c1a2a58371d4b9cc957fc7b17d59, type: 3}
   m_StaticBatchInfo:
     firstSubMesh: 0
     subMeshCount: 0

--- a/VirtualChefs/ProjectSettings/ProjectSettings.asset
+++ b/VirtualChefs/ProjectSettings/ProjectSettings.asset
@@ -144,8 +144,6 @@ PlayerSettings:
   - {fileID: 0}
   - {fileID: 0}
   - {fileID: 0}
-  - {fileID: -4458284507104142693, guid: 506454957f4a3b04999e64f068653335, type: 2}
-  - {fileID: 11400000, guid: c7f2d328c2450914ea9551bf9fdc592f, type: 2}
   metroInputSource: 0
   wsaTransparentSwapchain: 0
   m_HolographicPauseOnTrackingLoss: 1


### PR DESCRIPTION
Added tomato material to the tomato block's prefab as its absence was causing the tomato object in the main scene to switch from regular material to the missing pink material.